### PR TITLE
use gen_statem:start/3 since gen_fsm:start/3 is deprecated

### DIFF
--- a/src/my_request.erl
+++ b/src/my_request.erl
@@ -1,7 +1,7 @@
 -module(my_request).
 -author('Manuel Rubio <manuel@altenwald.com>').
 
--behaviour(gen_fsm).
+-behaviour(gen_statem).
 
 -define(SERVER, ?MODULE).
 

--- a/src/my_request.erl
+++ b/src/my_request.erl
@@ -46,7 +46,7 @@
             ParseQuery :: boolean()) -> {ok, pid()}.
 
 start(Socket, Id, Handler, ParseQuery) ->
-    {ok, Pid} = gen_fsm:start(?MODULE, [Socket, Id, Handler, ParseQuery], []),
+    {ok, Pid} = gen_statem:start(?MODULE, [Socket, Id, Handler, ParseQuery], []),
     gen_tcp:controlling_process(Socket, Pid),
     inet:setopts(Socket, [{active, true}]),
     {ok, Pid}.


### PR DESCRIPTION
gen_fsm:start/3 is [deprecated](http://erlang.org/doc/man/gen_fsm.html) and replaced by gen_statem:start/3 